### PR TITLE
Amend the constitution to use gender-neutral pronouns

### DIFF
--- a/constitution/05-application_of_income_and_property.tex
+++ b/constitution/05-application_of_income_and_property.tex
@@ -3,7 +3,7 @@
 \label{sec:income}
     \subsection{}The income and property of \shortname{} must be applied solely towards the promotion of the objects.
     \begin{enumerate}
-        \item A charity trustee is entitled to be reimbursed from the property of \shortname{} or may pay out of such property reasonable expenses properly incurred by him or her when acting on behalf of \shortname{}.
+        \item A charity trustee is entitled to be reimbursed from the property of \shortname{} or may pay out of such property reasonable expenses properly incurred by them when acting on behalf of \shortname{}.
         \item A charity trustee may benefit from trustee indemnity insurance cover purchased at \shortname{}'s expense in accordance with, and subject to the conditions in, section 189 of the Charities Act 2011.
     \end{enumerate}
 

--- a/constitution/06-benefits_and_payments_to_charity_trustees_and_connected_persons.tex
+++ b/constitution/06-benefits_and_payments_to_charity_trustees_and_connected_persons.tex
@@ -27,7 +27,7 @@
         \item The amount or maximum amount of the payment for the goods is set out in a written agreement between \shortname{} and the charity trustee or connected person supplying the goods (`the supplier').
         \item The amount or maximum amount of the payment for the goods does not exceed what is reasonable in the circumstances for the supply of the goods in question.
         \item The other charity trustees are satisfied that it is in the best interests of \shortname{} to contract with the supplier rather than with someone who is not a charity trustee or connected person. In reaching that decision the charity trustees must balance the advantage of contracting with a charity trustee or connected person against the disadvantages of doing so.
-        \item The supplier is absent from the part of any meeting at which there is discussion of the proposal to enter into a contract or arrangement with him or her or it with regard to the supply of goods to \shortname{}.
+        \item The supplier is absent from the part of any meeting at which there is discussion of the proposal to enter into a contract or arrangement with them with regard to the supply of goods to \shortname{}.
         \item The supplier does not vote on any such matter and is not to be counted when calculating whether a quorum of charity trustees is present at the meeting.
         \item The reason for their decision is recorded by the charity trustees in the minute book.
         \item A majority of the charity trustees then in office are not in receipt of remuneration or payments authorised by clause~\ref{sec:benefits}.

--- a/constitution/07-conflicts_of_interest_and_conflicts_of_loyalty.tex
+++ b/constitution/07-conflicts_of_interest_and_conflicts_of_loyalty.tex
@@ -3,7 +3,7 @@
 \label{sec:conflicts}
 A charity trustee must:
 \begin{enumerate}
-    \item declare the nature and extent of any interest, direct or indirect, which he or she has in a proposed transaction or arrangement with \shortname{} or in any transaction or arrangement entered into by \shortname{} which has not previously been declared; and
-    \item absent himself or herself from any discussions of the charity trustees in which it is possible that a conflict of interest will arise between his or her duty to act solely in the interests of \shortname{} and any personal interest (including but not limited to any  financial interest).
+    \item declare the nature and extent of any interest, direct or indirect, which they have in a proposed transaction or arrangement with \shortname{} or in any transaction or arrangement entered into by \shortname{} which has not previously been declared; and
+    \item absent themselves from any discussions of the charity trustees in which it is possible that a conflict of interest will arise between their duty to act solely in the interests of \shortname{} and any personal interest (including but not limited to any  financial interest).
 \end{enumerate}
-Any charity trustee absenting himself or herself from any discussions in accordance with this clause must not vote or be counted as part of the quorum in any decision of the charity trustees on the matter.
+Any charity trustee absenting themselves from any discussions in accordance with this clause must not vote or be counted as part of the quorum in any decision of the charity trustees on the matter.

--- a/constitution/09-membership.tex
+++ b/constitution/09-membership.tex
@@ -21,7 +21,7 @@
     Membership of \shortname{} cannot be transferred to anyone else except in the case of an individual or corporate body representing an organisation which is not incorporated, whose membership may be transferred by the unincorporated organisation to a new representative. Such transfer of membership does not take effect until \shortname{} has received written notification of the transfer.
 
     \subsection{Duty of Members}\label{sec:duty}
-    It is the duty of each member of \shortname{} to exercise his or her powers as a member of \shortname{} in the way he or she decides in good faith would be most likely to further the purposes of \shortname{}.
+    It is the duty of each member of \shortname{} to exercise their powers as a member of \shortname{} in the way they decide in good faith would be most likely to further the purposes of \shortname{}.
 
     \subsection{Termination of Membership}\label{sec:terminiation}
 
@@ -37,8 +37,8 @@
         \subsubsection{}
         Before the charity trustees take any decision to remove someone from membership of \shortname{} they must:
         \begin{enumerate}
-            \item inform the member of the reasons why it is proposed to remove him, her or it from membership;
-            \item give the member at least 21 clear days notice in which to make representations to the charity trustees as to why he, she or it should not be removed from membership;
+            \item inform the member of the reasons why it is proposed to remove them from membership;
+            \item give the member at least 21 clear days notice in which to make representations to the charity trustees as to why they should not be removed from membership;
             \item at a duly constituted meeting of the charity trustees, consider whether or not the member should be removed from membership;
             \item consider at that meeting any representations which the member makes as to why the member should not be removed; and
             \item allow the member, or the member's representative, to make those representations in person at that meeting, if the member so chooses.

--- a/constitution/09-membership.tex
+++ b/constitution/09-membership.tex
@@ -4,7 +4,7 @@
     \subsection{Admission of New Members}\label{sec:admission}
 
         \subsubsection{Eligibility}\label{sec:eligibility}
-        Membership of \shortname{} is open to anyone who is interested in furthering its purposes, and who, by applying for membership, has indicated his, her or its agreement to become a member and acceptance of the duty of members set out in clause~\ref{sec:duty}.
+        Membership of \shortname{} is open to anyone who is interested in furthering its purposes, and who, by applying for membership, has indicated their agreement to become a member and acceptance of the duty of members set out in clause~\ref{sec:duty}.
         A member may be an individual, a corporate body, or an individual or corporate body representing an organisation which is not incorporated.
 
         \subsubsection{Admission Procedure}\label{sec:admission_procedure}

--- a/constitution/12-charity_trustees.tex
+++ b/constitution/12-charity_trustees.tex
@@ -6,7 +6,7 @@
     The charity trustees shall manage the affairs of \shortname{} and may for that purpose exercise all the powers of \shortname{}. It is the duty of each charity trustee:
 
         \subsubsection{}
-        to exercise teir powers and to perform their functions as a trustee of \shortname{} in the way they decide in good faith would be most likely to further the purposes of \shortname{}; and
+        to exercise their powers and to perform their functions as a trustee of \shortname{} in the way they decide in good faith would be most likely to further the purposes of \shortname{}; and
 
         \subsubsection{}
         to exercise, in the performance of those functions, such care and skill as is reasonable in the circumstances having regard in particular to:

--- a/constitution/12-charity_trustees.tex
+++ b/constitution/12-charity_trustees.tex
@@ -6,13 +6,13 @@
     The charity trustees shall manage the affairs of \shortname{} and may for that purpose exercise all the powers of \shortname{}. It is the duty of each charity trustee:
 
         \subsubsection{}
-        to exercise his or her powers and to perform his or her functions as a trustee of \shortname{} in the way he or she decides in good faith would be most likely to further the purposes of \shortname{}; and
+        to exercise teir powers and to perform their functions as a trustee of \shortname{} in the way they decide in good faith would be most likely to further the purposes of \shortname{}; and
 
         \subsubsection{}
         to exercise, in the performance of those functions, such care and skill as is reasonable in the circumstances having regard in particular to:
         \begin{enumerate}
-            \item any special knowledge or experience that he or she has or holds himself or herself out as having; and
-            \item if he or she acts as a charity trustee of \shortname{} in the course of a business or profession, to any special knowledge or experience that it is reasonable to expect of a person acting in the course of that kind of business or profession.
+            \item any special knowledge or experience that they have or hold themselves out as having; and
+            \item if they act as a charity trustee of \shortname{} in the course of a business or profession, to any special knowledge or experience that it is reasonable to expect of a person acting in the course of that kind of business or profession.
         \end{enumerate}
 
     \subsection{Eligibility for Trusteeship}\label{sec:trustee_eligibility}
@@ -23,12 +23,12 @@
         \subsubsection{}
         No one may be appointed as a charity trustee:
         \begin{enumerate}
-            \item if he or she is under the age of 16 years; or
-            \item if he or she would automatically cease to hold office under the provisions of item~\ref{item:trustee_disqualification} of clause~\ref{sec:retirement}.
+            \item if they are under the age of 16 years; or
+            \item if they would automatically cease to hold office under the provisions of item~\ref{item:trustee_disqualification} of clause~\ref{sec:retirement}.
         \end{enumerate}
 
         \subsubsection{}
-        No one is entitled to act as a charity trustee whether on appointment or on any re-appointment until he or she has expressly acknowledged, in whatever way the charity trustees decide, his or her acceptance of the office of charity trustee.
+        No one is entitled to act as a charity trustee whether on appointment or on any re-appointment until they have expressly acknowledged, in whatever way the charity trustees decide, their acceptance of the office of charity trustee.
 
         \subsubsection{}
         At least one of the trustees of \shortname{} must be 18 years of age or over. If there is no trustee aged at least 18 years, the remaining trustee or trustees may act only to call a meeting of the charity trustees, or appoint a new charity trustee.

--- a/constitution/13-appointment_of_charity_trustees.tex
+++ b/constitution/13-appointment_of_charity_trustees.tex
@@ -4,7 +4,7 @@
     \subsection{Elected Charity Trustees}
 
         \subsubsection{}
-        At every annual general meeting of the members of \shortname{}, one-third of the elected charity trustees shall retire from office. If the number of elected charity trustees is not three or a multiple of three, then the number nearest to one-third shall retire from office, but if there is only one charity trustee, he or she shall retire;
+        At every annual general meeting of the members of \shortname{}, one-third of the elected charity trustees shall retire from office. If the number of elected charity trustees is not three or a multiple of three, then the number nearest to one-third shall retire from office, but if there is only one charity trustee, they shall retire;
 
         \subsubsection{}\label{sec:rotation_retirement}
         The charity trustees to retire by rotation shall be those who have been longest in office since their last appointment or reappointment. If any trustees were last appointed or reappointed on the same day those to retire shall (unless they otherwise agree among themselves) be determined by lot;
@@ -16,13 +16,13 @@
         The members or the charity trustees may at any time decide to appoint a new charity trustee, whether in place of a charity trustee who has retired or been removed in accordance with clause~\ref{sec:retirement_removal}, or as an additional charity trustee, provided that the limits specified in clause~\ref{sec:min_max} on the number of charity trustees would not as a result be exceeded;
 
         \subsubsection{}\label{sec:elected_trustee_retirement}
-        A person so appointed by the members of \shortname{} shall retire in accordance with the provisions of clauses~\ref{sec:trustee_vacancy} and~\ref{sec:trustee_vacancy}. A person so appointed by the charity trustees shall retire at the conclusion of the annual general meeting next following the date of his or her appointment, and shall not be counted for the purpose of determining which of the charity trustees is to retire by rotation at that meeting.
+        A person so appointed by the members of \shortname{} shall retire in accordance with the provisions of clauses~\ref{sec:trustee_vacancy} and~\ref{sec:trustee_vacancy}. A person so appointed by the charity trustees shall retire at the conclusion of the annual general meeting next following the date of their appointment, and shall not be counted for the purpose of determining which of the charity trustees is to retire by rotation at that meeting.
 
     \subsection{Ex Officio Charity Trustees}
     The `Conference Director' shall automatically, by virtue of holding that office (`ex officio'), be a charity trustee.
 
     If unwilling to act as a charity trustee, the Conference Director may:
     \begin{enumerate}
-        \item before accepting appointment as a charity trustee, give notice in writing to the trustees of his or her unwillingness to act in that capacity; or
+        \item before accepting appointment as a charity trustee, give notice in writing to the trustees of their unwillingness to act in that capacity; or
         \item after accepting appointment as a charity trustee, resign under the provisions contained in clause~\ref{sec:retirement_removal}.
     \end{enumerate}

--- a/constitution/14-information_for_new_charity_trustees.tex
+++ b/constitution/14-information_for_new_charity_trustees.tex
@@ -1,6 +1,6 @@
 %!TEX root = constitution.tex
 \section{Information for New Charity Trustees}\label{sec:new_trustees}
-The charity trustees will make available to each new charity trustee, on or before his or her first appointment:
+The charity trustees will make available to each new charity trustee, on or before their first appointment:
 \begin{enumerate}
     \item a copy of this constitution and any amendments made to it; and
     \item a copy of \shortname{}'s latest trustees’ annual report and statement of accounts.

--- a/constitution/15-retirement_and_removal_of_charity_trustees.tex
+++ b/constitution/15-retirement_and_removal_of_charity_trustees.tex
@@ -2,10 +2,10 @@
 \section{Retirement and Removal of Charity Trustees}\label{sec:retirement_removal}
 
     \subsection{}\label{sec:retirement}
-    A charity trustee ceases to hold office if he or she:
+    A charity trustee ceases to hold office if they:
     \begin{enumerate}
         \item retires by notifying \shortname{} in writing (but only if enough charity trustees will remain in office when the notice of resignation takes effect to form a quorum for meetings);
-        \item is absent without the permission of the charity trustees from all their meetings held within a period of six months and the trustees resolve that his or her office be vacated;
+        \item is absent without the permission of the charity trustees from all their meetings held within a period of six months and the trustees resolve that their office be vacated;
         \item dies;
         \item in the written opinion, given to \shortname{}, of a registered medical practitioner treating that person, has become physically or mentally incapable of acting as a trustee and may remain so for more than three months;
         \item is removed by the members of \shortname{} in accordance with clause~\ref{sec:removal} or

--- a/constitution/19-meetings_and_proceedings_of_charity_trustees.tex
+++ b/constitution/19-meetings_and_proceedings_of_charity_trustees.tex
@@ -12,7 +12,7 @@
     \subsection{Procedure at Meetings}
 
         \subsubsection{}
-        No decision shall be taken at a meeting unless a quorum is present at the time when the decision is taken. The quorum is two charity trustees, or the number nearest to one third of the total number of charity trustees, whichever is greater, or such larger number as the charity trustees may decide from time to time. A charity trustee shall not be counted in the quorum present when any decision is made about a matter upon which he or she is not entitled to vote.
+        No decision shall be taken at a meeting unless a quorum is present at the time when the decision is taken. The quorum is two charity trustees, or the number nearest to one third of the total number of charity trustees, whichever is greater, or such larger number as the charity trustees may decide from time to time. A charity trustee shall not be counted in the quorum present when any decision is made about a matter upon which they are not entitled to vote.
 
         \subsubsection{}
         Questions arising at a meeting shall be decided by a majority of those eligible to vote.

--- a/constitution/20-saving_provisions.tex
+++ b/constitution/20-saving_provisions.tex
@@ -11,4 +11,4 @@
     if, without the vote of that charity trustee and that charity trustee being counted in the quorum, the decision has been made by a majority of the charity trustees at a quorate meeting.
 
     \subsection{}\label{sec:invalid_benefits}
-    Clause~\ref{sec:invalid_voters} does not permit a charity trustee to keep any benefit that may be conferred upon him or her by a resolution of the charity trustees or of a committee of charity trustees if, but for clause~\ref{sec:invalid_voters}, the resolution would have been void, or if the charity trustee has not complied with clause~\ref{sec:conflicts}.
+    Clause~\ref{sec:invalid_voters} does not permit a charity trustee to keep any benefit that may be conferred upon them by a resolution of the charity trustees or of a committee of charity trustees if, but for clause~\ref{sec:invalid_voters}, the resolution would have been void, or if the charity trustee has not complied with clause~\ref{sec:conflicts}.

--- a/constitution/22-use_of_electronic_communications.tex
+++ b/constitution/22-use_of_electronic_communications.tex
@@ -14,7 +14,7 @@
     \subsection{Electronic Communication From \shortname{}}
 
         \subsubsection{}
-        Any member or charity trustee of \shortname{}, by providing \shortname{} with his or her email address or similar, is taken to have agreed to receive communications from \shortname{} in electronic form at that address, unless the member has indicated to \shortname{} his or her unwillingness to receive such communications in that form.
+        Any member or charity trustee of \shortname{}, by providing \shortname{} with their email address or similar, is taken to have agreed to receive communications from \shortname{} in electronic form at that address, unless the member has indicated to \shortname{} their unwillingness to receive such communications in that form.
 
         \subsubsection{}
         The charity trustees may, subject to compliance with any legal requirements, by means of publication on its website:


### PR DESCRIPTION
This patch modifies the constitution to use gender-neutral pronouns “they/them”, rather than gendered pronouns “he/him” and “she/her”. I think I’ve got them all, but I haven’t been through with a fine-toothed comb to check.

(§28 explains how an amendment to the constitution is accepted, but doesn’t give a mechanism for proposing one. A pull request felt like a good starting point.)