### PR TITLE
Correct section 13 references

### DIFF
--- a/constitution/13-appointment_of_charity_trustees.tex
+++ b/constitution/13-appointment_of_charity_trustees.tex
@@ -3,20 +3,20 @@
 
     \subsection{Elected Charity Trustees}
 
-        \subsubsection{}
+        \subsubsection{}\label{sec:one_third_retire}
         At every annual general meeting of the members of \shortname{}, one-third of the elected charity trustees shall retire from office. If the number of elected charity trustees is not three or a multiple of three, then the number nearest to one-third shall retire from office, but if there is only one charity trustee, he or she shall retire;
 
         \subsubsection{}\label{sec:rotation_retirement}
         The charity trustees to retire by rotation shall be those who have been longest in office since their last appointment or reappointment. If any trustees were last appointed or reappointed on the same day those to retire shall (unless they otherwise agree among themselves) be determined by lot;
 
         \subsubsection{}\label{sec:trustee_vacancy}
-        The vacancies so arising may be  filled by the decision of the members at the annual general meeting; any vacancies not  filled at the annual general meeting may be  filled as provided in clause~\ref{sec:elected_trustee_retirement};
+        The vacancies so arising may be  filled by the decision of the members at the annual general meeting; any vacancies not  filled at the annual general meeting may be  filled as provided in clause~\ref{sec:appoint_new_trustee};
 
-        \subsubsection{}
+        \subsubsection{}\label{sec:appoint_new_trustee}
         The members or the charity trustees may at any time decide to appoint a new charity trustee, whether in place of a charity trustee who has retired or been removed in accordance with clause~\ref{sec:retirement_removal}, or as an additional charity trustee, provided that the limits specified in clause~\ref{sec:min_max} on the number of charity trustees would not as a result be exceeded;
 
         \subsubsection{}\label{sec:elected_trustee_retirement}
-        A person so appointed by the members of \shortname{} shall retire in accordance with the provisions of clauses~\ref{sec:trustee_vacancy} and~\ref{sec:trustee_vacancy}. A person so appointed by the charity trustees shall retire at the conclusion of the annual general meeting next following the date of his or her appointment, and shall not be counted for the purpose of determining which of the charity trustees is to retire by rotation at that meeting.
+        A person so appointed by the members of \shortname{} shall retire in accordance with the provisions of clauses~\ref{sec:one_third_retire} and~\ref{sec:rotation_retirement}. A person so appointed by the charity trustees shall retire at the conclusion of the annual general meeting next following the date of his or her appointment, and shall not be counted for the purpose of determining which of the charity trustees is to retire by rotation at that meeting.
 
     \subsection{Ex Officio Charity Trustees}
     The `Conference Director' shall automatically, by virtue of holding that office (`ex officio'), be a charity trustee.


### PR DESCRIPTION
Our constitution is based upon a model document provided by the Charity Commission at https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/562468/Association_Model_Constitution.pdf

The references in Section 13 were copied incorrectly from that document and are corrected in this PR.